### PR TITLE
fix: improve openapi docs rendering

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -122,6 +122,7 @@ const config: Config = {
   plugins: [
     path.resolve(__dirname, './plugins/inject-scripts.js'),
     path.resolve(__dirname, './plugins/fix-docusaurus-navbar.js'),
+    path.resolve(__dirname, './plugins/fix-auth-openapi.js'),
     [
       'docusaurus-plugin-openapi-docs',
       {

--- a/plugins/fix-auth-openapi.js
+++ b/plugins/fix-auth-openapi.js
@@ -1,0 +1,64 @@
+/* docusaurus-plugin-openapi-docs: Fix rendering of auth details in endpoint pages using markdown. */
+module.exports = function (context, options) {
+    return {
+        name: 'fix-auth-openapi',
+        injectHtmlTags() {
+            return {
+                postBodyTags: [
+                    {
+                        tagName: 'script',
+                        attributes: {
+                            src: 'https://cdn.jsdelivr.net/npm/marked/marked.min.js',
+                            defer: true,
+                        },
+                    },
+                    {
+                        tagName: 'script',
+                        innerHTML: `
+                            function renderMarkdownInAuthDetails() {
+                                const detailsSections = document.querySelectorAll('.openapi-security__details pre');
+
+                                detailsSections.forEach((preElement) => {
+                                    const descriptionSpans = preElement.querySelectorAll('span');
+
+                                    descriptionSpans.forEach((descriptionDiv) => {
+                                        if (descriptionDiv.innerHTML.includes('description:')) {
+                                            const descriptionText = descriptionDiv.innerHTML.split('description:')[1].trim();
+
+                                            const htmlContent = window.marked ? window.marked.parse(descriptionText) : descriptionText;
+
+                                            const newContainer = document.createElement('div');
+                                            newContainer.innerHTML = htmlContent;
+                                            descriptionDiv.innerHTML = '<b>description:</b> ' + newContainer.innerHTML;
+                                        }
+                                    });
+                                });
+                            }
+
+                            function initRender() {
+                                if (window.marked) {
+                                    renderMarkdownInAuthDetails();
+                                } else {
+                                    setTimeout(initRender, 100);
+                                }
+
+                                const observer = new MutationObserver((mutations) => {
+                                    mutations.forEach((mutation) => {
+                                        if (mutation.type === 'childList' && mutation.target.querySelector('.openapi-security__details')) {
+                                            renderMarkdownInAuthDetails();
+                                        }
+                                    });
+                                });
+
+                                observer.observe(document.body, { childList: true, subtree: true });
+                            }
+
+                            window.addEventListener('load', initRender);
+                            document.addEventListener('DOMContentLoaded', initRender);
+                        `,
+                    },
+                ],
+            };
+        },
+    };
+};

--- a/plugins/fix-docusaurus-navbar.js
+++ b/plugins/fix-docusaurus-navbar.js
@@ -21,6 +21,9 @@ module.exports = function (context, options) {
                   if (hasActiveChild && dropdownLink) {
                     dropdownLink.classList.add('navbar__link--active');
                   }
+                  else {
+                    dropdownLink.classList.remove('navbar__link--active');
+                  }
                 });
               }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -232,6 +232,7 @@ body {
   font-size: inherit;
 }
 
+
 .openapi-security__details pre code {
   border: 0.1rem solid rgba(0, 0, 0, 0.1);
 }
@@ -240,8 +241,13 @@ body {
   border-top: 0;
 }
 
+.openapi-security__details pre p {
+  margin-bottom: 5px;
+  white-space: normal;
+}
+
 .openapi-security__details .openapi-security__summary-header {
-  margin: 0;
+  margin: 0 !important;
 }
 
 /* docusaurus-plugin-openapi-docs: Increase code snippets max height */
@@ -254,7 +260,12 @@ body {
   --ifm-code-font-size: 100%;
 }
 
+/* docusaurus-plugin-openapi-docs: Customize embedded schema */
 .embedded-schema {
   margin-top: 1rem;
   margin-bottom: 1rem;
+}
+
+.embedded-schema .openapi__heading {
+  display: none;
 }


### PR DESCRIPTION
Closes https://github.com/MONEI/docs/issues/270

1. Fixes authorization details rendering:

    ![image](https://github.com/user-attachments/assets/f42d1f95-bf1c-43f4-accc-d09e216c78d4)

2. Hides custom embedded schema title.

3. Fixes navbar highlighting when switching between pages.