### PR TITLE
chore: update MONEI Components documentation for React 19 compatibility

### DIFF
--- a/docs/monei-js/overview.mdx
+++ b/docs/monei-js/overview.mdx
@@ -9,9 +9,9 @@ MONEI Components is a set of rich, prebuilt Components that help you create your
 
 Components include features like:
 
-- Format Card information automatically as it’s entered
-- Translate placeholders to your customer’s preferred language
-- Use responsive design to fit the width of your customer’s screen or mobile device
+- Format Card information automatically as it's entered
+- Translate placeholders to your customer's preferred language
+- Use responsive design to fit the width of your customer's screen or mobile device
 - Customize the styling to match the look and feel of your checkout flow
 - Apple Pay, Google Pay, PayPal, Bizum Сomponents for easy integration into your checkout flow
 - All MONEI Components are available in JavaScript, ReactJS, Vue and Angular
@@ -20,8 +20,8 @@ Components include features like:
 
 You need to include `monei.js` in your checkout page by either adding the script tag to the `head` of your HTML file, or by importing it from the `monei-js` [module](https://www.npmjs.com/package/@monei-js/components):
 
-import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
 
 <Tabs
   defaultValue="html"
@@ -336,6 +336,25 @@ const App = () => {
 ReactDOM.render(<App />, document.getElementById('root'));
 ```
 
+:::note Temporary Fix for React 19
+If you're using React 19 and experiencing issues with MONEI Components, you can use the following temporary fix:
+
+```jsx
+// Import findDOMNode from external library
+import {findDOMNode} from 'find-dom-node-polyfill';
+
+// Set Find DOM Node before driver
+ReactDOM.findDOMNode = findDOMNode;
+
+const CardInputComponent: React.FC<CardInputProps> = CardInput.driver('react', {
+  React: React,
+  ReactDOM: ReactDOM
+});
+```
+
+This workaround addresses the removal of `ReactDOM.findDOMNode` in React 19 by using the external library. We're working on a permanent solution that will be available in the next major version of MONEI Components.
+:::
+
 </TabItem>
 
 <TabItem value="css">
@@ -368,7 +387,7 @@ ReactDOM.render(<App />, document.getElementById('root'));
 
 </Tabs>
 
-[![Edit monei-card-input-react](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/monei-card-input-react-uw2lr?fontsize=14&hidenavigation=1&theme=dark)
+[![Edit monei-card-input-react-19](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/monei-card-input-react-forked-8cm7qm?file=/src/index.tsx:10,1-16,4)
 
 </TabItem>
 <TabItem value="vue">
@@ -528,29 +547,6 @@ The Card Input Component lets you collect Credit Card information all within one
 
 </Tabs>
 
-Card Input Component is completely customizable. You can style it to match the look and feel of your site, providing a seamless checkout experience for your customers. It’s also possible to style various input states, for example when the input has focus.
+Card Input Component is completely customizable. You can style it to match the look and feel of your site, providing a seamless checkout experience for your customers. It's also possible to style various input states, for example when the input has focus.
 
 To see all available MONEI Components check the [API docummentation](monei-js/reference.md) or our integration guides for individual payment methods.
-
-## React 19 Compatibility
-
-:::note Temporary Fix for React 19
-If you're using React 19 and experiencing issues with MONEI Components, you can use the following temporary fix:
-
-```jsx
-// Import findDOMNode from external library
-import {findDOMNode} from 'find-dom-node-polyfill';
-
-// Set Find DOM Node before driver
-ReactDOM.findDOMNode = findDOMNode;
-
-const CardInputComponent: React.FC<CardInputProps> = CardInput.driver('react', {
-  React: React,
-  ReactDOM: ReactDOM
-});
-```
-
-This workaround addresses the removal of `ReactDOM.findDOMNode` in React 19 by using the external library. We're working on a permanent solution that will be available in the next major version of MONEI Components.
-:::
-
-[![Edit monei-card-input-react-19](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/monei-card-input-react-forked-8cm7qm?file=/src/index.tsx:10,1-16,4)


### PR DESCRIPTION
- Added a temporary fix for React 19 to address the removal of `ReactDOM.findDOMNode`.
- Updated code examples and links to reflect the new workaround.
- Improved overall clarity and consistency in the documentation.