### PR TITLE
chore: update CSS styles for code blocks and prism syntax highlighting

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -255,8 +255,12 @@ body {
   max-height: 800px;
 }
 
-.openapi-explorer__playground-editor {
-  --ifm-code-font-size: 100%;
+.openapi-explorer__code-block code {
+  font-size: inherit !important;
+}
+
+.prism-code {
+  font-size: 0.9rem !important;
 }
 
 /* docusaurus-plugin-openapi-docs: Customize embedded schema */


### PR DESCRIPTION
- Adjusted font size for `.openapi-explorer__code-block code` to inherit from parent styles for better consistency.
- Set font size for `.prism-code` to 0.9rem to enhance readability of syntax-highlighted code.